### PR TITLE
Fixed typo in the title of the Vanilla template.

### DIFF
--- a/templates/vanilla/index.html
+++ b/templates/vanilla/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Crete Tailwind App</title>
+    <title>Create Tailwind App</title>
     <link rel="stylesheet" href="/style.css" />
   </head>
 


### PR DESCRIPTION
The file `create-tw/templates/vanilla/index.html` had a typo in the title tag. Fixed it in this PR.