### PR TITLE
Resolve the failures for installation with yarn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import installTailwind from "./cli/output/installTailwind.js";
 import installDependencies from "./cli/output/installDependencies.js";
 import figlet from "figlet";
 import createProject from "./cli/output/createProject.js";
+import path from 'path'
+import { COMMON_TEMPLATES_ROOT } from "./constants";
 
 process.once("SIGINT", () => {
   process.exit(1);
@@ -31,6 +33,7 @@ async function main() {
 
   logger.info(`\nUsing: ${chalk.cyan.bold(pkgManager)}\n`);
 
+
   if (fs.existsSync(projectDir)) {
     // Ask to overwrite
     const answer = await inquirer.prompt({
@@ -48,6 +51,15 @@ async function main() {
   }
 
   await createProject(input);
+  
+    // Add yarn.lock in project folder so the dependencies installation won't fail
+  if (pkgManager === 'yarn') {
+	await fs.copy(
+		 path.join(COMMON_TEMPLATES_ROOT, "yarn.lock"),
+		 path.join(projectDir, "yarn.lock"),
+	);
+  }
+  
   await installTailwind(input);
   await installDependencies(input);
 


### PR DESCRIPTION
When installing the application with Yarn => 
[Yarn installation](https://postimg.cc/Fdkj711C)

You got an error when the dependencies are installed => [Error before change](https://postimg.cc/WDhZHtmp)

The modification just adds a yarn.lock file ( the file is located in templates/common folder )
and copy this file in the project if the package manager is Yarn after the project creation and before the dependencies installation.

[After change](https://postimg.cc/wRTRDvBd)

